### PR TITLE
add this.opts to update conditional

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ export default class extends Phaser.Sprite {
 
 	update () {
 		super.update()
-		if (this.opts.watch) {
+		if (this.opts && this.opts.watch) {
 			const newWidth = this.bg.width * (this.opts.watch.host[this.opts.watch.value] / this.opts.watch.max)
 
 			if (this.opts.resize || (!this.opts.bgSprite && !this.opts.fgSprite)) {


### PR DESCRIPTION
Phaser was crashing because the this.opts.watch is undefined until runCreation is finished. This just adds a first check for this.opts before checking for this.opts.watch for the early running of the update cycle.